### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ So you will always have something like the following:
 ```
 Blueprint directory (also the default blueprint name)
 * blueprint.json
-* artifacts
+* Artifacts
     - artifact.json
     - ...
     - more-artifacts.json


### PR DESCRIPTION
Changed the artifacts folder case in the example as when using Import-AzBlueprintWithArtifact on Linux it won't discover the artifacts if the folder doesn't have the correct case.