### PR TITLE
add apiVersion to reference functions

### DIFF
--- a/samples/001-builtins/ASBF/artifact.hub-shared-network-firewall.json
+++ b/samples/001-builtins/ASBF/artifact.hub-shared-network-firewall.json
@@ -203,7 +203,7 @@
                       ],
                       "sourceIpGroups": [],
                       "destinationAddresses": [
-                        "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('azure-fw-ip-name'))).ipAddress]"
+                        "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('azure-fw-ip-name')), '2019-11-01').ipAddress]"
                       ],
                       "destinationPorts": [
                         "3389"

--- a/samples/001-builtins/ASBF_Gov/artifact.hub-shared-network-firewall.json
+++ b/samples/001-builtins/ASBF_Gov/artifact.hub-shared-network-firewall.json
@@ -203,7 +203,7 @@
                       ],
                       "sourceIpGroups": [],
                       "destinationAddresses": [
-                        "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('azure-fw-ip-name'))).ipAddress]"
+                        "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('azure-fw-ip-name')), '2019-11-01').ipAddress]"
                       ],
                       "destinationPorts": [
                         "3389"


### PR DESCRIPTION
fixes #63 

When installing the blueprint with deployHub = false, an error occurs in the evaluation of the reference(...). This is fixed by addition of the apiVersion.