### PR TITLE
Add Azure Blueprints retirement notice and retirement issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Azure Blueprints retirement announcement & timeline
+    url: https://aka.ms/AzureBlueprintsRetirementAnnouncement
+    about: Official announcement, the phased retirement timeline, and what changes at each phase.
+  - name: Migrate from Azure Blueprints
+    url: https://aka.ms/AzureBlueprintsMigration
+    about: Step-by-step guidance to migrate to Azure Deployment Stacks and template specs.
+  - name: Azure Blueprints retirement FAQ
+    url: https://aka.ms/AzureBlueprintsRetirementFAQ
+    about: Answers to common questions about the retirement, data export, and deny-assignment impact.

--- a/.github/ISSUE_TEMPLATE/retirement-question.yml
+++ b/.github/ISSUE_TEMPLATE/retirement-question.yml
@@ -1,0 +1,69 @@
+name: Azure Blueprints retirement question / issue
+description: Ask a question or report a problem related to the Azure Blueprints (Preview) retirement and migration.
+title: "[Retirement]: "
+labels: ["retirement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Azure Blueprints (Preview) is being retired on **January 31, 2027**, with a phased retirement beginning **July 31, 2026**.
+
+        Most questions are answered in the official resources — please skim these first:
+        - [Retirement announcement & full timeline](https://aka.ms/AzureBlueprintsRetirementAnnouncement)
+        - [Migration guidance](https://aka.ms/AzureBlueprintsMigration)
+        - [Retirement FAQ](https://aka.ms/AzureBlueprintsRetirementFAQ)
+
+        Please don't include subscription IDs, tenant IDs, secrets, or other sensitive details in this issue.
+  - type: textarea
+    id: question
+    attributes:
+      label: Your retirement question or issue
+      description: What would you like help with? Include any concerns about the timeline or a specific migration blocker.
+      placeholder: e.g. How do I preserve my blueprint locks (deny assignments) after retirement?
+    validations:
+      required: true
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      description: What is this mostly about?
+      options:
+        - Migration guidance (Deployment Stacks / template specs)
+        - Retirement timeline or phased dates
+        - Resource locks / deny assignments
+        - Exporting blueprint definitions, versions, or assignments
+        - Policy or role assignments
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: current-usage
+    attributes:
+      label: How are you using Azure Blueprints today?
+      description: Briefly describe your definitions, assignments, scope (management group / subscription), and artifact types. Keep it free of sensitive identifiers.
+      placeholder: e.g. ~10 definitions assigned at a management group scope, using policy + role + template artifacts and resource locks.
+    validations:
+      required: false
+  - type: dropdown
+    id: migration-target
+    attributes:
+      label: Migration path you're considering
+      description: Which replacement are you evaluating? See the migration guidance for details.
+      options:
+        - Not sure yet
+        - Azure Deployment Stacks
+        - Template specs
+        - Git-based templates
+        - Azure Policy (for policy assignments)
+        - Other / a combination
+    validations:
+      required: false
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Before you submit
+      options:
+        - label: I've reviewed the retirement announcement, migration guidance, and FAQ linked above.
+          required: true
+        - label: This issue does not contain subscription IDs, tenant IDs, secrets, or other sensitive data.
+          required: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ Last edited: 7-3-19
 -->
 # Managing Blueprints as Code
 
+> [!IMPORTANT]
+> **Azure Blueprints (Preview) is being retired on January 31, 2027**, with a phased retirement beginning July 31, 2026. At retirement, the API stops responding, the Azure CLI and Azure PowerShell commands stop working, and Blueprints is removed from the Azure portal. **Export any blueprint definitions, versions, and assignments you want to keep before January 31, 2027** — anything not exported is deleted and can't be recovered.
+>
+> **Recommended migration:** move to [Azure Deployment Stacks](https://learn.microsoft.com/azure/azure-resource-manager/bicep/deployment-stacks) for resource grouping, lifecycle management, and deny-assignment (lock) enforcement, and publish your templates as [template specs](https://learn.microsoft.com/azure/azure-resource-manager/bicep/template-specs) or store them in Git for versioning.
+>
+> **Phased timeline**
+> - **Jul 31, 2026** — no new blueprint definitions or versions
+> - **Oct 31, 2026** — no edits to definitions; no new assignments
+> - **Dec 31, 2026** — no edits to existing assignments
+> - **Jan 31, 2027** — Azure Blueprints is retired
+>
+> **Resources**
+> - Announcement & full timeline: https://aka.ms/AzureBlueprintsRetirementAnnouncement
+> - Migration guidance: https://aka.ms/AzureBlueprintsMigration
+> - FAQ: https://aka.ms/AzureBlueprintsRetirementFAQ
+>
+> Have a retirement-related question? [Open a retirement question / issue](https://github.com/Azure/azure-blueprints/issues/new?template=retirement-question.yml).
+
 Using the Blueprints in the Azure Portal is a great way to get started with Blueprints or to use Blueprints on a small-ish scale, but often you’ll want to manage your Blueprints as code for a variety of reasons, such as:
 * Sharing blueprints
 * Keeping blueprints in source control


### PR DESCRIPTION
## Summary

Azure Blueprints (Preview) is being retired on **January 31, 2027**, with a phased retirement beginning **July 31, 2026** ([announcement](https://aka.ms/AzureBlueprintsRetirementAnnouncement)). This PR surfaces that notice in the repo and gives customers a clear path to ask retirement / migration questions.

## Changes

- **README.md** — adds a prominent retirement notice at the top: the retirement date, the phased timeline, the recommended migration path (Azure Deployment Stacks + template specs / Git), and links to the announcement, migration guidance, and FAQ.
- **.github/ISSUE_TEMPLATE/retirement-question.yml** — a new issue form for retirement-specific questions and issues.
- **.github/ISSUE_TEMPLATE/config.yml** — keeps blank issues enabled and adds quick links to the announcement, migration guidance, and FAQ.

## References

- Retirement announcement &amp; timeline: https://aka.ms/AzureBlueprintsRetirementAnnouncement
- Migration guidance: https://aka.ms/AzureBlueprintsMigration
- FAQ: https://aka.ms/AzureBlueprintsRetirementFAQ
- Learn docs: https://learn.microsoft.com/azure/governance/blueprints/blueprint-retirement

## Notes

- Opened as a **draft** for review of the public wording before it goes live.
- The retirement issue form references a `retirement` label; maintainers may want to create that label so it's applied automatically (GitHub ignores it gracefully if it doesn't exist).
